### PR TITLE
Add iproute2 to list of apt packages to install

### DIFF
--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -6,6 +6,7 @@ RUN set -ex && \
             curl \
             dnsutils \
             iftop \
+            iproute2 \
             jq \
             net-tools \
             netcat \


### PR DESCRIPTION
Adds the iproute2 package which provides the useful `ip` command along
with other tools that provide more advanced features than the legacy
`net-tools` and `route` package.

For more documentation: https://packages.debian.org/buster/iproute2